### PR TITLE
Fix backend HTTP redirect preventing list loading

### DIFF
--- a/backend/ShoppingList.Api/Program.cs
+++ b/backend/ShoppingList.Api/Program.cs
@@ -30,7 +30,6 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-app.UseHttpsRedirection();
 app.UseCors(CorsPolicy);
 
 // API endpoints


### PR DESCRIPTION
## Summary
- remove automatic HTTPS redirection so frontend can call backend over HTTP

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_689ee58381f4832aaf2bc680ab51a746